### PR TITLE
Implementation fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
       <artifactId>workflow-job</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20210307</version>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/io/jenkins/plugins/sample/CredentialUtil.java
+++ b/src/main/java/io/jenkins/plugins/sample/CredentialUtil.java
@@ -7,13 +7,15 @@ import hudson.security.ACL;
 import java.util.Collections;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import hudson.model.TaskListener;
 
 public class CredentialUtil {
 
-    public static String getSecretToken(String credentialId) {
+    public static String getSecretToken(String credentialId, TaskListener listener) {
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         if (jenkins == null) {
-            throw new IllegalStateException("Jenkins instance is not available.");
+            listener.getLogger().println("Jenkins instance is not available.");
+            return null;
         }
 
         // Fetch the secret text credential

--- a/src/main/java/io/jenkins/plugins/sample/PipelineDataPublisher.java
+++ b/src/main/java/io/jenkins/plugins/sample/PipelineDataPublisher.java
@@ -29,7 +29,6 @@ public class PipelineDataPublisher extends RunListener<Run<?, ?>> {
 
         // prepare data
         String jobName = run.getParent().getFullName();
-        String id = run.getId();
         String referenceId = generateUUID();
         Integer startTime = (int) (run.getStartTimeInMillis() / 1000);
         Integer duration = (int) (run.getDuration() / 1000);
@@ -61,16 +60,15 @@ public class PipelineDataPublisher extends RunListener<Run<?, ?>> {
         listener.getLogger().println("pipeline_source: Jenkins");
         listener.getLogger().println("reference_id: " + referenceId);
         listener.getLogger().println("started_at: " + startTime);
-        listener.getLogger().println("finished_at: " + finishTime + "ms");
+        listener.getLogger().println("finished_at: " + finishTime);
         listener.getLogger().println("status: " + status);
 
         DxDataSender.sendData(
-                path + "/api/pipelineRuns.notify",
+                path + "/api/pipelineRuns.sync",
                 "{" + "\"pipeline_name\": \""
                         + jobName + "\"," + "\"pipeline_source\": \"Jenkins\","
                         + "\"reference_id\": \""
-                        + referenceId + "\"," + "\"id\": \""
-                        + id + "\"," + "\"started_at\": \""
+                        + referenceId + "\"," + "\"started_at\": \""
                         + startTime + "\"," + "\"finished_at\": \""
                         + finishTime + "\"," + "\"status\": \""
                         + status + "\"" + "}",

--- a/src/main/java/io/jenkins/plugins/sample/PipelineDataPublisher.java
+++ b/src/main/java/io/jenkins/plugins/sample/PipelineDataPublisher.java
@@ -43,12 +43,12 @@ public class PipelineDataPublisher extends RunListener<Run<?, ?>> {
 
         // Fetch Api Key
         CredentialUtil credentialManager = new CredentialUtil();
-        String authToken = credentialManager.getSecretToken("dx_token");
+        String authToken = credentialManager.getSecretToken("dx_token", listener);
         if (authToken == null) {
             listener.getLogger().println("Authentication token not found for key: dx_token");
             return;
         }
-        String path = credentialManager.getSecretToken("dx_path");
+        String path = credentialManager.getSecretToken("dx_path", listener);
         if (path == null) {
             listener.getLogger().println("Authentication token not found for key: dx_path");
             return;
@@ -72,6 +72,7 @@ public class PipelineDataPublisher extends RunListener<Run<?, ?>> {
                         + startTime + "\"," + "\"finished_at\": \""
                         + finishTime + "\"," + "\"status\": \""
                         + status + "\"" + "}",
-                authToken);
+                authToken,
+                listener);
     }
 }


### PR DESCRIPTION
- update to match latest DX API (/api/pipelineRuns.notify -> /api/pipelineRuns.sync, remove "id" param)
- parse response from DX to display error message/type
- if jenkins instance is null, handle consistently (output the issue to the console and return null)
- confirmed: onCompleted will fire for all pipelines, whether they end in success or failure (https://wiki.jenkins-ci.org/JENKINS/Terminology.html)

Testing:
- Happy path: run locally, was able to create Pipeline::Run records
- Sad path: was able to create errors (not_authed, invalid_auth, account_inactive, required_params_missing) and see them output to the console